### PR TITLE
Removed ambiguity

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 GLWT Public License
 Copyright (c) [year] [fullname]
 
-The author has no f**king clue what the code in this project does.
+The author has no fucking clue what the code in this project does.
 It might just work or not, there is no third option.
 
 Everyone is permitted to copy, distribute, modify, merge, sell, publish,
@@ -11,7 +11,7 @@ sublicense or whatever you want with this software but at your OWN RISK.
                 GOOD LUCK WITH THAT PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION, AND MODIFICATION
 
-0. You just DO WHAT THE F*CK YOU WANT TO as long as you NEVER LEAVE A
+0. You just DO WHAT THE FUCK YOU WANT TO as long as you NEVER LEAVE A
 TRACE TO TRACK THE AUTHOR of the original product.
 
 IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,


### PR DESCRIPTION
According to _Contra proferentem_, if there was a way to replace the *s with a string of letters that would modify the license against the intent of the original author, it would be legal.